### PR TITLE
Автопубликация архива с релизом

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js: 6
+before_script:
+  - npm install -g gulp
+  - npm install -g bower 
+  - npm install
+  - bower install
+
+script:
+    - gulp build
+    - gulp docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ before_script:
 script:
     - gulp build
 #    - gulp docs - error docs build now
-    - tree -D
+#    - tree -D
     - tar -zcvf clickhouse-frontend.tar.gz -C .. /clickhouse-frontend --exclude=clickhouse-frontend/clickhouse-frontend.tar.gz
 
-addons:
-  apt:
-    packages:
-        - tree
+# for travis state view, debug deploy
+#addons:
+#  apt:
+#    packages:
+#        - tree
 
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ before_script:
 
 script:
     - gulp build
-    - gulp docs
+#    - gulp docs - error docs build now
+    - tree -D

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ script:
     - gulp build
 #    - gulp docs - error docs build now
 #    - tree -D
-    - tar -zcf ../clickhouse-frontend.tar.gz -C .. clickhouse-frontend
+
+before_deploy:
+    - mv docs clickhouse-frontend
+    - tar -zcf clickhouse-frontend.tar.gz clickhouse-frontend
 
 # for travis state view, debug deploy
 #addons:
@@ -26,4 +29,4 @@ deploy:
     tags: true
   api_key: $GITHUB_TOKEN
   file:
-    - "../clickhouse-frontend.tar.gz"
+    - "clickhouse-frontend.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
     - gulp build
 #    - gulp docs - error docs build now
 #    - tree -D
-    - tar -zcvf clickhouse-frontend.tar.gz -C .. /clickhouse-frontend --exclude=clickhouse-frontend/clickhouse-frontend.tar.gz
+    - tar -zcvf clickhouse-frontend.tar.gz -C .. clickhouse-frontend --exclude=clickhouse-frontend/clickhouse-frontend.tar.gz
 
 # for travis state view, debug deploy
 #addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 6
+node_js: "6.7.0"
 before_script:
   - npm install -g gulp
   - npm install -g bower 
@@ -10,8 +10,19 @@ script:
     - gulp build
 #    - gulp docs - error docs build now
     - tree -D
+    - tar -zcvf clickhouse-frontend.tar.gz -C .. /clickhouse-frontend --exclude=clickhouse-frontend/clickhouse-frontend.tar.gz
 
 addons:
   apt:
     packages:
         - tree
+
+deploy:
+  skip_cleanup: true
+  tags: true
+  provider: releases
+  on:
+    tags: true
+  api_key: $GITHUB_TOKEN
+  file:
+    - "clickhouse-frontend.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ script:
     - gulp build
 #    - gulp docs - error docs build now
     - tree -D
+
+addons:
+  apt:
+    packages:
+        - tree

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
     - gulp build
 #    - gulp docs - error docs build now
 #    - tree -D
-    - tar -zcf clickhouse-frontend.tar.gz -C .. clickhouse-frontend --exclude=clickhouse-frontend.tar.gz
+    - tar -zcf ../clickhouse-frontend.tar.gz -C .. clickhouse-frontend
 
 # for travis state view, debug deploy
 #addons:
@@ -26,4 +26,4 @@ deploy:
     tags: true
   api_key: $GITHUB_TOKEN
   file:
-    - "clickhouse-frontend.tar.gz"
+    - "../clickhouse-frontend.tar.gz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
     - gulp build
 #    - gulp docs - error docs build now
 #    - tree -D
-    - tar -zcvf clickhouse-frontend.tar.gz -C .. clickhouse-frontend --exclude=clickhouse-frontend/clickhouse-frontend.tar.gz
+    - tar -zcf clickhouse-frontend.tar.gz -C .. clickhouse-frontend --exclude=clickhouse-frontend.tar.gz
 
 # for travis state view, debug deploy
 #addons:


### PR DESCRIPTION
Предлагаю сделать автоматическую сборку архива с релизом для разворачивания на своём сервере вместо хранения их в папке docs:

1. История не засоряется одноразовыми файлами от минимизации
2. То что на сервер можно просто положить папку docs, а не настраивать npm, gulp и т.п. - не очевидно.
3. скачать-распаковать архив удобнее, чем клонировать git-репозиторий для получения одной папки.
4. Можно не заморачиваться тем чтобы не забыть закоммитить скомпилированные файлы в папку docs

После добавления интеграции с travis при каждом пуше в репозиторий будет запускаться сборка проекта и публикация архива папки docs - чтобы конечный пользователь смог просто скачать архив и распаковать его у себя на сервере.
(на самом деле сборка будет запускаться при каждом пуше, но архив создается/закачивается только для тегов)

результат можно посмотреть в моём форке:
https://github.com/rekby/clickhouse-frontend/releases/tag/t2