### PR TITLE
Fix building Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,4 @@ docker-compose.*
 .idea/
 .vagrant/
 .vscode/
-docs/
 todo


### PR DESCRIPTION
 Образ не собирался из-за того, что в .dockerignore присутствует строка docs.