### PR TITLE
Set default language to en

### DIFF
--- a/src/app/index.config.js
+++ b/src/app/index.config.js
@@ -117,8 +117,9 @@
             .translations('ru', {
             })
             .registerAvailableLanguageKeys(['en', 'ru'], {
-                'en_*': 'en',
-                'ru_*': 'ru'
+                'ru_*': 'ru',
+                'ru-*': 'ru',
+                '*': 'en',
             })
             .determinePreferredLanguage();
             // this line used for translation check


### PR DESCRIPTION
#36 Вариант 'ru-*' нужен для chrome потому что там передается - вместо _